### PR TITLE
Handle multiple subscription line items being passed as params.

### DIFF
--- a/app/decorators/spree/controllers/orders/create_subscription_line_items.rb
+++ b/app/decorators/spree/controllers/orders/create_subscription_line_items.rb
@@ -14,16 +14,33 @@ module Spree
         def self.prepended(base)
           base.after_action(
             :handle_subscription_line_items,
-            only: :populate,
-            if: ->{ params[:subscription_line_item] }
+            only: [:populate, :populate_multiple],
+            if: -> { params[:subscription_line_item] }
           )
         end
 
         private
 
+        # This method has been changed to accept multiple subscribable_id's
+        # Required params:
+        #   "subscription_line_item"=>{
+        #     ...
+        #     "subscribable_id"=>{"variant_id"=>"subscribable_id"}
+        #     ...
+        #   }
+        # Example params:
+        #   "subscription_line_item"=>{
+        #     ...
+        #     "subscribable_id"=>{"1"=>"4"}
+        #     ...
+        #   }
         def handle_subscription_line_items
-          line_item = @current_order.line_items.find_by(variant_id: params[:variant_id])
-          create_subscription_line_item(line_item)
+          variant_ids = params[:subscription_line_item][:subscribable_id].keys
+          line_items = @current_order.line_items.where(variant_id: variant_ids)
+          line_items.each do |line_item|
+            subscribable_id = params[:subscription_line_item][:subscribable_id][line_item.variant_id.to_s]
+            create_subscription_line_item(line_item, subscribable_id)
+          end
         end
       end
     end

--- a/app/models/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/app/models/solidus_subscriptions/subscription_line_item_builder.rb
@@ -2,10 +2,11 @@ module SolidusSubscriptions
   module SubscriptionLineItemBuilder
     private
 
-    def create_subscription_line_item(line_item)
-      SolidusSubscriptions::LineItem.create!(
-        subscription_params.merge(spree_line_item: line_item)
-      )
+    def create_subscription_line_item(line_item, subscribable_id)
+      merged_params = subscription_params.merge(spree_line_item: line_item)
+      merged_params["subscribable_id"] = subscribable_id
+      SolidusSubscriptions::LineItem.create!(merged_params)
+
 
       # Rerun the promotion handler to pickup subscription promotions
       Spree::PromotionHandler::Cart.new(line_item.order).activate


### PR DESCRIPTION
Updated this gem for Tier 2 of [Issue #1360](https://github.com/GobyHQ/goby/issues/1360)